### PR TITLE
Add whitespace support by trimming before split

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
         $scope.$watch('squadText', function(newVal, oldVal){
           if(newVal){
             var multipliedValues = _.map(newVal.split(/[,]+/), function(el){
-              var elements = el.split(/[ x\*]+/i);
+              var elements = el.trim().split(/[ x\*]+/i);
               if (elements.length < 2 || !elements[1]) return el;
               elements = elements.map(e => parseInt(e)).sort((a,b) => a-b);
 


### PR DESCRIPTION
Simple fix that lets users use white space when entering their squad players. This fixes #8.